### PR TITLE
Added ssh private key path to ansible section of Vagrantfile

### DIFF
--- a/{{cookiecutter.repo_name}}/Vagrantfile_multi
+++ b/{{cookiecutter.repo_name}}/Vagrantfile_multi
@@ -63,6 +63,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           ansible.limit = 'all'
           ansible.ask_sudo_pass = true
           ansible.host_key_checking = false
+          ansible.raw_ssh_args = ['-o IdentityFile={{cookiecutter.private_ssh_key_path}}']
           # ansible.verbose = 'vvvv'
           # ansible.tags = ['tag_name', 'another_tag']
         end

--- a/{{cookiecutter.repo_name}}/Vagrantfile_single
+++ b/{{cookiecutter.repo_name}}/Vagrantfile_single
@@ -45,6 +45,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.limit = 'all'
     ansible.ask_sudo_pass = true
     ansible.host_key_checking = false
+    ansible.raw_ssh_args = ['-o IdentityFile={{cookiecutter.private_ssh_key_path}}']
     # ansible.verbose = 'vvvv'
     # ansible.tags = ['tag_name', 'another_tag']
   end


### PR DESCRIPTION
I was getting SSH auth errors on the site.yml playbook and realized that ansible was trying to use the vagrant insecure ssh key to login as the django user but that user did not have that key installed.  In most cases I think this would only be affected by running vagrant provision.  If someone was running ansible-playbook manually then this would be handled in their ~/.ssh/config or with ansible setting of private_key_file.
